### PR TITLE
Activate the window on process exit

### DIFF
--- a/ProcessWatcher.csproj
+++ b/ProcessWatcher.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <PublishSingleFile>true</PublishSingleFile>
+    <PublishSingleFile Condition="'$(Configuration)' == 'Release'">true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/ProcessWatcherApp.cs
+++ b/ProcessWatcherApp.cs
@@ -170,6 +170,8 @@
         {
             this.BeginInvoke(new Action(() =>
                 {
+                    this.Activate();
+
                     if (!this.shuttingDown)
                     {
                         this.numTicksRemaining = Settings.Default.CountdownTimer;


### PR DESCRIPTION
Make sure the window becomes active after the watched process exits.
This ensures that the user can interact with it.

Also fix PublishSingleFile to only apply to Release builds. Debugging
seemingly isn't possible with this option enabled.
